### PR TITLE
feat: data-birb-target attribute, scale cap, sticky note size persistence

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -304,7 +304,7 @@ function startApplication(birbPixels, featherPixels, hatsPixels) {
 			} else {
 				newMultiplier = currentMultiplier + 1;
 			}
-			newMultiplier = Math.max(0.25, Math.round(newMultiplier * 4) / 4);
+			newMultiplier = Math.max(0.25, Math.min(5, Math.round(newMultiplier * 4) / 4));
 			userSettings.birbScaleMultiplier = newMultiplier;
 			save();
 			updateBirbScale();

--- a/src/context.js
+++ b/src/context.js
@@ -42,7 +42,7 @@ export class Context {
 	 * @returns {string[]} A list of CSS selectors for focusable elements
 	 */
 	getFocusableElements() {
-		return ["img", "video", ".birb-sticky-note"];
+		return ["img", "video", ".birb-sticky-note", "[data-birb-target]"];
 	}
 
 	getFocusElementTopMargin() {

--- a/src/stickyNotes.js
+++ b/src/stickyNotes.js
@@ -12,6 +12,8 @@ import {
  * @property {string} content
  * @property {number} top
  * @property {number} left
+ * @property {number} [width]
+ * @property {number} [height]
  */
 
 export class StickyNote {
@@ -21,13 +23,17 @@ export class StickyNote {
 	 * @param {string} [content]
 	 * @param {number} [top]
 	 * @param {number} [left]
+	 * @param {number} [width]
+	 * @param {number} [height]
 	 */
-	constructor(id, site = "", content = "", top = 0, left = 0) {
+	constructor(id, site = "", content = "", top = 0, left = 0, width, height) {
 		this.id = id;
 		this.site = site;
 		this.content = content;
 		this.top = top;
 		this.left = left;
+		this.width = width;
+		this.height = height;
 	}
 }
 
@@ -56,7 +62,8 @@ export function renderStickyNote(stickyNote, page, onSave, onDelete) {
 	const content = makeElement("birb-window-content");
 	const textarea = document.createElement("textarea");
 	textarea.className = "birb-sticky-note-input";
-	textarea.style.width = "150px";
+	textarea.style.width = stickyNote.width ? `${stickyNote.width}px` : "150px";
+	textarea.style.height = stickyNote.height ? `${stickyNote.height}px` : "";
 	textarea.placeholder = "Write your notes here and they'll stick to the page!";
 	textarea.value = stickyNote.content;
 	content.appendChild(textarea);
@@ -96,6 +103,21 @@ export function renderStickyNote(stickyNote, page, onSave, onDelete) {
 				onSave();
 			}, 250);
 		});
+
+		// Persist size on resize
+		/** @type {ReturnType<typeof setTimeout>|undefined} */
+		let resizeTimeout;
+		const resizeObserver = new ResizeObserver(() => {
+			stickyNote.width = textarea.offsetWidth;
+			stickyNote.height = textarea.offsetHeight;
+			if (resizeTimeout) {
+				clearTimeout(resizeTimeout);
+			}
+			resizeTimeout = setTimeout(() => {
+				onSave();
+			}, 250);
+		});
+		resizeObserver.observe(textarea);
 	}
 
 	// On window resize


### PR DESCRIPTION
## Changes

### 1. `data-birb-target` attribute support (addresses #19)
Any element with `data-birb-target` is now a valid perch target for the bird. This lets site owners make buttons, cards, and other interactive elements bird-friendly without needing `<img>` tags.

```html
<button data-birb-target>Click me</button>
<div data-birb-target class="card">...</div>
```

### 2. Cap birb scale at 5x (closes #25)
The scale multiplier is now capped at `Math.min(5, ...)` to prevent the bird from growing so large it covers the entire UI and becomes impossible to interact with.

### 3. Persist sticky note size (closes #29)
Sticky note width and height are now saved via `ResizeObserver` and restored on load, so notes maintain their size across page reloads.

---

**Testing:** Verified all three changes in the embed build. The `data-birb-target` selector works alongside existing `img`, `video`, and `.birb-sticky-note` targets.